### PR TITLE
Fixed passing NULL array from get_instance

### DIFF
--- a/swig/cmpi.i
+++ b/swig/cmpi.i
@@ -300,7 +300,10 @@ data_value(const CMPIData *dp)
     result = Target_Null;
     Target_INCREF(result);
   }
-  else if ((dp->type) & CMPI_ARRAY) {
+  else if (dp->state & CMPI_null) {
+    result = value_value(&(dp->value), CMPI_null);
+  }
+  else if (!(dp->state & CMPI_nullValue) && (dp->type & CMPI_ARRAY)) {
     int size = CMGetArrayCount(dp->value.array, NULL);
     int i;
     result = Target_SizedArray(size);

--- a/swig/python/cmpi_pywbem_bindings.py
+++ b/swig/python/cmpi_pywbem_bindings.py
@@ -883,6 +883,8 @@ class CMPIProxyProvider(object):
     def cmpi2pywbem_data(self, cdata, _type=None, is_array=None):
         #TODO check for valid cdata.state
         #TODO error handling
+        if (cdata.state & cmpi.CMPI_nullValue) > 0:
+            return None
         if _type is None:
             _type, is_array = _cmpi_type2string(cdata.type)
         attr = _type


### PR DESCRIPTION
I have a python provider and I want to return an instance with NULL value of
string[](or any other array) property.

Therefore I have in my get_instance method:
model['MyProperty'] = pywbem.CIMProperty(
    name='MyProperty',
    value=None,
    type='string',
    array_size=0,
    is_array=True)

Under Pegasus CIMOM I get traceback, because Pegasus pedantically checks
property types;
  File "/usr/lib/python2.7/site-packages/cmpi_pywbem_bindings.py", line 761, in pywbem2cmpi_inst
      cinst.set_property(str(prop.name), data, ctype)
  File "/usr/lib/python2.7/site-packages/cmpi.py", line 809, in set_property
      return _cmpi.CMPIInstance_set_property(self, *args)
  CIMError: (1, '61')

This patch adds two checks for NULL value of array and makes sure that the
CIMOM really gets NULL value of the property.
