### PR TITLE
Fix EmbeddedInstances as instance properties.

### DIFF
--- a/swig/python/cmpi_pywbem_bindings.py
+++ b/swig/python/cmpi_pywbem_bindings.py
@@ -782,8 +782,10 @@ class CMPIProxyProvider(object):
         #            prop.name.lower() not in pinst.property_list:
         #        continue
             try:
-                data, _type = self.pywbem2cmpi_value(prop.value, 
-                                                     _type=prop.type)
+                _type = prop.type
+                if _type == "string" and prop.embedded_object:
+                    _type = prop.embedded_object
+                data, _type = self.pywbem2cmpi_value(prop.value, _type=_type)
             except TypeError, te:
                 raise TypeError('Error converting Property %s: Value %s, Type %s; %s' % (prop.name, prop.value, prop.type, str(te)))
             ctype = _pywbem2cmpi_typemap[_type]


### PR DESCRIPTION
Set correct CMPI type when setting string property with EmbeddedInstance
qualifier.

For example, a provider may set string property as embedded instance:

model['MyEmbeddedProperty'] = CIMInstance(...)

The CIMProperty object, which gets created for this property, will have:

```
property.type = 'string'
property.embedded_object = 'instance'
```

(see CIMProperty constructor).

In order to use the right CMPI type when converting this property to CMPI
data, we should consider also property.embedded_object and not only .type.

This patch changes resulting CMPI type from CMPI_string to CMPI_instance
for such embedded instances.
