### PR TITLE
Added CMPIContext to CMPIProxyProvider

### DIFF
--- a/src/target_python.c
+++ b/src/target_python.c
@@ -370,11 +370,13 @@ TargetInitialize(ProviderMIHandle* hdl, CMPIStatus* st)
     return -1; 
   }
   PyObject *broker = SWIG_NewPointerObj((void*) hdl->broker, SWIGTYPE_p__CMPIBroker, 0);
-  PyObject *args = PyTuple_New(2); 
+  PyObject *ctx = SWIG_NewPointerObj((void*) hdl->context, SWIGTYPE_p__CMPIContext, 0);
+  PyObject *args = PyTuple_New(3);
   _SBLIM_TRACE(1,("\n<%d/0x%x> >>>>> TargetInitialize(Python) called, MINAME=%s\n",
                getpid(), pthread_self(), hdl->miName));
-  PyTuple_SetItem(args, 0, string2target(hdl->miName)); 
-  PyTuple_SetItem(args, 1, broker); 
+  PyTuple_SetItem(args, 0, string2target(hdl->miName));
+  PyTuple_SetItem(args, 1, broker);
+  PyTuple_SetItem(args, 2, ctx);
   
   /* provinst = cmpi_pywbem_bindings::get_cmpi_proxy_provider( miName, broker ) */
   PyObject *provinst = PyObject_CallObject(provclass, args); 

--- a/swig/python/cmpi_pywbem_bindings.py
+++ b/swig/python/cmpi_pywbem_bindings.py
@@ -447,25 +447,25 @@ class ProviderEnvironment(object):
 
 g_proxies = {}
 
-def get_cmpi_proxy_provider(miname, broker):
+def get_cmpi_proxy_provider(miname, broker, ctx):
     try:
         prox = g_proxies[miname]
         if prox.proxy.env.proxy.broker != broker:
                 raise pywbem.CIMError(pywbem.CIM_ERR_FAILED, 
                         'New broker not the same as cached broker!')
     except KeyError:
-        prox = ExceptionClassWrapper(CMPIProxyProvider(miname, broker))
+        prox = ExceptionClassWrapper(CMPIProxyProvider(miname, broker, ctx))
         g_proxies[miname] = prox
     return prox
 
 
 class CMPIProxyProvider(object):
 
-    def __init__(self, miname, broker):
+    def __init__(self, miname, broker, ctx):
         print 'called CMPIProxyProvider(', miname, ',', broker, ')'
         self.miname = miname
         self.broker = broker
-        env = ProviderEnvironment(self, None)
+        env = ProviderEnvironment(self, ctx)
         provmod = miname
         if provmod[0] != '/':
             provmod = '/usr/lib/pycim/' + provmod


### PR DESCRIPTION
When CMPIProxyProvider loads a python module and calls its functions (e.g.
get_providers), it should provide full 'env' parameter to these functions.

My provider is multi-threaded and creates some threads as early as in
get_providers function. For this I need env.get_cimom_handle() to work there so
I can call PrepareAttachThread / AttachThread. Without this patch I get
SIGSEGV, since the returned CIMOM handle is None.
