### PR TITLE
Access to CMPIContext through ContextWrap.

### DIFF
--- a/swig/python/cmpi_pywbem_bindings.py
+++ b/swig/python/cmpi_pywbem_bindings.py
@@ -214,7 +214,7 @@ class ContextWrap(object):
     def todict(self):
         d = {}
         for i in xrange(0, self.cmpicontext.get_entry_count()):
-            data, name = self.cmpicontext.get_entry_at(i)
+            name, data = self.cmpicontext.get_entry_at(i)
             _type, is_array = _cmpi_type2string(data.type)
             pval = self.proxy.cmpi2pywbem_data(data, _type, is_array)
             d[name] = pval


### PR DESCRIPTION
Hello,

I've come into this issue with ContextWrap class. According to this snippet from `swig/cmpi_types.i:1623`:

``` c
    TARGET_THREAD_BEGIN_BLOCK;
    tdata = data_data(&data);
#if defined (SWIGPYTHON)
    result = PyTuple_New(2);
    PyTuple_SetItem(result, 0, PyString_FromString(name));
    PyTuple_SetItem(result, 1, tdata);
#else
    result = Target_SizedArray(2);
    Target_Append(result, Target_String(name));
    Target_Append(result, tdata);
#endif
```

The data attribute comes as second after the name. I've tested this under tog-pegasus but haven't checked the other bindings.
