### PR TITLE
Accept unicode strings from python functions

### DIFF
--- a/src/target_python.c
+++ b/src/target_python.c
@@ -265,7 +265,7 @@ TargetCall(ProviderMIHandle* hdl, CMPIStatus* st,
         prstr = PyTuple_GetItem(prv, 1); 
     }
 
-    if (! PyInt_Check(prc) || (! PyString_Check(prstr) && prstr != Py_None))
+    if (! PyInt_Check(prc) || (prstr != Py_None && ! PyString_Check(prstr) && ! PyUnicode_Check(prstr)))
     {
         TARGET_THREAD_BEGIN_ALLOW;
         char* str = fmtstr("Python function \"%s\" didn't return a {<int>, <str>) two-tuple", opname); 


### PR DESCRIPTION
When a provider raises Exception with unicode string, such as:
        raise pywbem.CIMError(pywbem.CIM_ERR_FAILED, u"Error message")
A client gets the error message:
lmiwbem_core.CIMError: (1, 'CIM_ERR_FAILED: Python function "invoke_method" didn\'t return a {<int>, <str>) two-tuple')

With the proposed fix the message would be:
lmiwbem_core.CIMError: (1, 'CIM_ERR_FAILED: Error message')
