### PR TITLE
Fix build error with gcc14.

### DIFF
--- a/src/target_python.c
+++ b/src/target_python.c
@@ -154,6 +154,7 @@ cleanup:
 static int
 PyGlobalInitialize(const CMPIBroker* broker, CMPIStatus* st)
 {
+  const wchar_t proname[] = L"cmpi_swig";
 /*  _SBLIM_TRACE(1,("<%d/0x%x> PyGlobalInitialize() called", getpid(), pthread_self())); */
   
   if (_TARGET_INIT)
@@ -165,7 +166,7 @@ PyGlobalInitialize(const CMPIBroker* broker, CMPIStatus* st)
   
   _SBLIM_TRACE(1,("<%d/0x%x> Python: Loading", getpid(), pthread_self()));
   
-  Py_SetProgramName("cmpi_swig");
+  Py_SetProgramName(proname);
   Py_Initialize();
 #if PY_MAJOR_VERSION < 3
   SWIGEXPORT void SWIG_init(void);


### PR DESCRIPTION
| cmpi-bindings/1.0.4/git/swig/python/../../src/target_python.c:168:21: error: passing argument 1 of 'Py_SetProgramName' from incompatible pointer type [-Wincompatible-pointer-types]
|   168 |   Py_SetProgramName("cmpi_swig");
|       |                     ^~~~~~~~~~~
|       |                     |
|       |                     char *
| cmpi-bindings/1.0.4/recipe-sysroot/usr/include/python3.12/pylifecycle.h:37:56: note: expected 'const wchar_t *' {aka 'const unsigned int *'} but argument is of type 'char *'
|    37 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) Py_SetProgramName(const wchar_t *);
|       |                                                        ^~~~~~~~~~~~~~~